### PR TITLE
Add marker files to package data

### DIFF
--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -27,10 +27,13 @@ setup(
     classifiers=[
       'Development Status :: 3 - Alpha',
       'Intended Audience :: Developers',
+      'Intended Audience :: Science/Research',
+      'Topic :: Scientific/Engineering :: Physics',
       'Programming Language :: Python :: 3',
     ],
     keywords='{{cookiecutter.keywords}}',
     packages=find_packages(exclude=['docs', 'tests*']),
+    package_data={'{{cookiecutter.app_name}}': ['*.yapsy-plugin']},
     include_package_data=True,
     author='{{cookiecutter.author_name}}',
     install_requires=install_requires,


### PR DESCRIPTION
...and more classifiers

This design requires that marker files be in the package root.